### PR TITLE
Hide event buttons on absent action url

### DIFF
--- a/src/Components/parts/Buttons.js
+++ b/src/Components/parts/Buttons.js
@@ -2,17 +2,32 @@ import React from 'react';
 import { Col } from 'react-bootstrap';
 
 const DualButtons = (props) => {
-    return <Col className='dualButtons' xs={12}>
+    
+    const slidesButton = props.firstLink 
+    ? (
+        <a rel="noopener noreferrer" target="_blank" href={props.firstLink}>
+          <div className={'myButton myButton--colourless myButton--colourless--' + props.group}>
+            {props.firstButtonText}          
+          </div>
+        </a>
+      ) 
+    : undefined;
+    
+    const facebookEventButton = props.secondLink
+      ? (
+        <a rel="noopener noreferrer" target="_blank" href={props.secondLink}>
+          <div className={'myButton myButton--colored myButton--colored--' + props.group} >{props.secondButtonText}</div>
+        </a>
+        )
+      : undefined
+  
+    return (
+      <Col className='dualButtons' xs={12}>
         <div style={{ marginTop: '50px' }}>
-            <a rel="noopener noreferrer" target="_blank" href={props.firstLink}>
-                <div className={'myButton myButton--colourless myButton--colourless--' + props.group}>{props.firstButtonText}</div>
-            </a>
-            <a rel="noopener noreferrer" target="_blank" href={props.secondLink}>
-                <div className={'myButton myButton--colored myButton--colored--' + props.group} >{props.secondButtonText}</div>
-            </a>
+            {slidesButton}
+            {facebookEventButton}
         </div>
-
-    </Col>
+    </Col>)
 }
 
 const Button = (props) => {


### PR DESCRIPTION
This PR hides the action buttons under the events when they do not have defined url

**Without Links**
![Screenshot from 2020-06-11 19-47-46](https://user-images.githubusercontent.com/17273872/84416582-15eb6980-ac1d-11ea-81b9-cfd691e2d942.png)

**Only one link - v1**
![Screenshot from 2020-06-11 19-47-56](https://user-images.githubusercontent.com/17273872/84416421-dae93600-ac1c-11ea-9389-5d629b02950c.png)


**Only one link - v2**
![Screenshot from 2020-06-11 19-48-05](https://user-images.githubusercontent.com/17273872/84416419-da509f80-ac1c-11ea-9740-b901c5598c71.png)

**Both of them**
![Screenshot from 2020-06-11 19-48-14](https://user-images.githubusercontent.com/17273872/84416415-d91f7280-ac1c-11ea-951b-fa049ff1654b.png)



